### PR TITLE
Fix paths to caches for Bazel in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,8 +27,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            "~/.cache/bazel"
-            "~/.cache/bazel-repo"
+            ~/.cache/bazel
+            ~/.cache/bazel-repo
           key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
           restore-keys: bazel-cache-
       - name: bazel test //...


### PR DESCRIPTION
This fixes paths to caches for Bazel in CI, in the same way aspect-build/rules_js#366 fixed.